### PR TITLE
Makefile now checks which 'docker compose' command to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Try "docker compose" first, then fallback to "docker-compose"
+DOCKER_COMPOSE_COMMAND := $(shell command -v docker-compose >/dev/null 2>&1 && echo docker-compose || (command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1 && echo "docker compose"))
+
+# If neither exists, abort
+ifeq ($(DOCKER_COMPOSE_COMMAND),)
+$(error "Neither docker-compose nor docker compose found in PATH")
+endif
+
 all: build
 
 build:
@@ -11,10 +19,10 @@ upload:
 	docker tag nbe:latest nulldevil/nbe:latest
 	docker push nulldevil/nbe:latest
 up:
-	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True docker-compose -f docker-compose.yml up -d
+	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True $(DOCKER_COMPOSE_COMMAND) -f docker-compose.yml up -d
 down:
-	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True docker-compose -f docker-compose.yml down
+	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True $(DOCKER_COMPOSE_COMMAND) -f docker-compose.yml down
 up_aarch64:
-	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True docker-compose -f docker-compose_aarch64.yml up -d
+	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True $(DOCKER_COMPOSE_COMMAND) -f docker-compose_aarch64.yml up -d
 down_aarch64:
-	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True docker-compose -f docker-compose_aarch64.ym down
+	COMPOSE_PROJECT_NAME=nbe COMPOSE_IGNORE_ORPHANS=True $(DOCKER_COMPOSE_COMMAND) -f docker-compose_aarch64.yml down


### PR DESCRIPTION
A small change in order to figure out that I'm doing the pull request the right way before doing bigger pull requests.

This change is to let the Makefile identify whether to use "docker-compose" or "docker compose" as the compose command.

Also a typo was fixed for down_aarch64 target.